### PR TITLE
fix(client): guard association parent lookup without source

### DIFF
--- a/packages/client/src/data-source/__tests__/data-block/DataBlockProvider.test.tsx
+++ b/packages/client/src/data-source/__tests__/data-block/DataBlockProvider.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@tachybase/test/client';
 
+import AssociationCreateWithoutSourceIdDemo from './data-block-demos/association-create-without-source-id';
 import AssociationTableListAndParentRecordDemo from './data-block-demos/association-table-list-and-parent-record';
 import AssociationTableListAndSourceIdDemo from './data-block-demos/association-table-list-and-source-id';
 import CollectionFormCreateDemo from './data-block-demos/collection-form-create';
@@ -94,6 +95,18 @@ describe('CollectionDataSourceProvider', () => {
   });
 
   describe('association', () => {
+    test('Association create does not request parent record when sourceId is missing', async () => {
+      render(<AssociationCreateWithoutSourceIdDemo />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('parent-record')).toHaveTextContent('no parent');
+      });
+      const parentRecordRequests = (AssociationCreateWithoutSourceIdDemo as any).mock.history.get.filter((item) =>
+        item.url?.startsWith('users:get'),
+      );
+      expect(parentRecordRequests).toEqual([]);
+    });
+
     test('Table list & sourceId', async () => {
       const { getByText, getByRole } = render(<AssociationTableListAndSourceIdDemo />);
 

--- a/packages/client/src/data-source/__tests__/data-block/data-block-demos/association-create-without-source-id.tsx
+++ b/packages/client/src/data-source/__tests__/data-block/data-block-demos/association-create-without-source-id.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {
+  SchemaComponent,
+  useCollectionParentRecordData,
+  UseDataBlockProps,
+  withDynamicSchemaProps,
+} from '@tachybase/client';
+import { ISchema } from '@tachybase/schema';
+
+import { createApp } from './createApp';
+
+const collection = 'users';
+const associationField = 'roles';
+const association = `${collection}.${associationField}`;
+
+const schema: ISchema = {
+  type: 'void',
+  name: 'root',
+  'x-decorator': 'DataBlockProvider',
+  'x-use-decorator-props': 'useBlockDecoratorProps',
+  'x-decorator-props': {
+    association,
+  },
+  'x-component': 'CardItem',
+  properties: {
+    demo: {
+      type: 'void',
+      'x-component': 'ParentRecordViewer',
+    },
+  },
+};
+
+const ParentRecordViewer = withDynamicSchemaProps(() => {
+  const parentRecord = useCollectionParentRecordData<{ id?: number; username?: string }>();
+  return <div data-testid="parent-record">{parentRecord?.username ?? 'no parent'}</div>;
+});
+
+const useBlockDecoratorProps: UseDataBlockProps<'AssociationCreate'> = () => {
+  return {};
+};
+
+const Demo = () => {
+  return <SchemaComponent schema={schema}></SchemaComponent>;
+};
+
+const Root = createApp(
+  Demo,
+  {
+    components: { ParentRecordViewer },
+    scopes: { useBlockDecoratorProps },
+  },
+  {
+    [`${collection}:get?filter[id]=undefined`]: {
+      id: 999,
+      username: 'Unexpected parent',
+    },
+  },
+);
+
+export default Root;

--- a/packages/client/src/data-source/__tests__/data-block/data-block-demos/createApp.tsx
+++ b/packages/client/src/data-source/__tests__/data-block/data-block-demos/createApp.tsx
@@ -54,5 +54,6 @@ export function createApp(Demo: ComponentType<any>, options: ApplicationOptions 
   });
 
   const Root = app.getRootComponent();
+  Root['mock'] = mock;
   return Root;
 }

--- a/packages/client/src/data-source/data-block/DataBlockRequestProvider.tsx
+++ b/packages/client/src/data-source/data-block/DataBlockRequestProvider.tsx
@@ -63,12 +63,10 @@ function useParentRequest<T>(options: Omit<AllDataBlockProps, 'type'>) {
   return useRequest<T>(
     async () => {
       if (parentRecord) return Promise.resolve({ data: parentRecord });
-      if (!association || !sourceKey) return Promise.resolve({ data: undefined });
+      if (!association || !sourceKey || sourceId == null) return Promise.resolve({ data: undefined });
       // "association": "Collection.Field"
       const arr = association.split('.');
-      // <collection>:get/<filterByTk>
-      const url = `${arr[0]}:get?filter[${sourceKey}]=${sourceId}`;
-      const res = await api.request({ url, headers });
+      const res = await api.resource(arr[0], undefined, headers).get({ filter: { [sourceKey]: sourceId } });
       return res.data;
     },
     {


### PR DESCRIPTION
Skip parent record requests when an association source is not persisted. Cover the unsaved association create path with a regression test.