### PR TITLE
fix(client): normalize custom filter variables

### DIFF
--- a/packages/client/src/filter-provider/__tests__/transformToFilter.ts
+++ b/packages/client/src/filter-provider/__tests__/transformToFilter.ts
@@ -58,7 +58,7 @@ describe('transformToFilter', () => {
     });
   });
 
-  it('should use current field component to infer $dateBetween when stored operators are empty', () => {
+  it('should use current date-only range field component to infer $dateBetween when stored operators are empty', () => {
     const start = '2026-04-13T00:00:00.000Z';
     const end = '2026-04-19T23:59:59.999Z';
     const values = {
@@ -95,7 +95,45 @@ describe('transformToFilter', () => {
       $and: [
         {
           createdAt: {
-            $dateBetween: [dayjs(start).startOf('day').toISOString(), dayjs(end).endOf('day').toISOString()],
+            $dateBetween: [dayjs(start).toISOString(), dayjs(end).toISOString()],
+          },
+        },
+      ],
+    });
+  });
+
+  it('should preserve explicit $dateBetween times for datetime range fields', () => {
+    const start = '2026-04-13T00:00:00.000Z';
+    const end = '2026-04-19T18:45:00.000Z';
+    const values = {
+      createdAt: [start, end],
+    };
+
+    const fieldSchema = {
+      'x-filter-operators': {
+        createdAt: '$dateBetween',
+      },
+      properties: {
+        createdAt: {
+          name: 'createdAt',
+          'x-component-props': {
+            component: 'DatePicker.RangePicker',
+            showTime: true,
+          },
+        },
+      },
+    };
+
+    const getField = () => ({
+      targetKey: undefined,
+      interface: 'createdAt',
+    });
+
+    expect(transformToFilter(values, fieldSchema as any, getField, 'receipt')).toEqual({
+      $and: [
+        {
+          createdAt: {
+            $dateBetween: [dayjs(start).toISOString(), dayjs(end).toISOString()],
           },
         },
       ],

--- a/packages/client/src/filter-provider/utils.ts
+++ b/packages/client/src/filter-provider/utils.ts
@@ -169,10 +169,17 @@ const resolveFilterOperator = (
   return getDefaultFilterOperatorValue(fieldSchema, operatorList);
 };
 
+const hasExplicitTime = (value: any) => {
+  return typeof value === 'string' && /[T\s]\d{2}:\d{2}/.test(value);
+};
+
 const normalizeDateBetweenBoundary = (value: any, boundary: 'start' | 'end') => {
   const m = dayjs(value);
   if (!m.isValid()) {
     return value;
+  }
+  if (hasExplicitTime(value)) {
+    return m.toISOString();
   }
   return (boundary === 'start' ? m.startOf('day') : m.endOf('day')).toISOString();
 };

--- a/packages/client/src/filter-provider/utils.ts
+++ b/packages/client/src/filter-provider/utils.ts
@@ -121,6 +121,9 @@ const findSchemaByName = (schema: any, name: string): any => {
 
   const properties = schema.properties || {};
   for (const key of Object.keys(properties)) {
+    if (key === name) {
+      return properties[key];
+    }
     const found = findSchemaByName(properties[key], name);
     if (found) {
       return found;
@@ -169,22 +172,66 @@ const resolveFilterOperator = (
   return getDefaultFilterOperatorValue(fieldSchema, operatorList);
 };
 
+type NormalizeDateBetweenOptions = {
+  useDefaultDateBoundary?: boolean;
+};
+
+const isDateOnlyString = (value: any) => {
+  return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value);
+};
+
 const hasExplicitTime = (value: any) => {
   return typeof value === 'string' && /[T\s]\d{2}:\d{2}/.test(value);
 };
 
-const normalizeDateBetweenBoundary = (value: any, boundary: 'start' | 'end') => {
-  const m = dayjs(value);
+const isDefaultDateBoundaryValue = (value: any, boundary: 'start' | 'end') => {
+  if (isDateOnlyString(value)) {
+    return true;
+  }
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const match = value.match(/^\d{4}-\d{2}-\d{2}[T\s](\d{2}:\d{2}:\d{2})(?:\.\d{3})?(?:Z|[+-]\d\d:\d\d)?$/);
+  if (!match) {
+    return false;
+  }
+  return boundary === 'start' ? match[1] === '00:00:00' : match[1] === '23:59:59';
+};
+
+const normalizeDefaultDateBoundaryInput = (value: any) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  return value.replace(/Z$/, '').replace(/[+-]\d\d:\d\d$/, '');
+};
+
+const normalizeDateBetweenBoundary = (
+  value: any,
+  boundary: 'start' | 'end',
+  options: NormalizeDateBetweenOptions = {},
+) => {
+  const rawValue = options.useDefaultDateBoundary ? normalizeDefaultDateBoundaryInput(value) : value;
+  const m = dayjs(rawValue);
   if (!m.isValid()) {
     return value;
   }
-  if (hasExplicitTime(value)) {
+  if (!options.useDefaultDateBoundary && hasExplicitTime(rawValue) && !isDateOnlyString(rawValue)) {
     return m.toISOString();
   }
   return (boundary === 'start' ? m.startOf('day') : m.endOf('day')).toISOString();
 };
 
-export const normalizeDateBetweenValue = (value: any[]) => {
+const shouldApplyDefaultDateBoundary = (start: any, end: any, options: NormalizeDateBetweenOptions = {}) => {
+  if (!options.useDefaultDateBoundary) {
+    return false;
+  }
+  if (isDateOnlyString(start) || isDateOnlyString(end)) {
+    return true;
+  }
+  return isDefaultDateBoundaryValue(start, 'start') && isDefaultDateBoundaryValue(end, 'end');
+};
+
+export const normalizeDateBetweenValue = (value: any[], options: NormalizeDateBetweenOptions = {}) => {
   const normalized = value.filter(Boolean);
   if (normalized.length === 0) {
     return null;
@@ -192,7 +239,22 @@ export const normalizeDateBetweenValue = (value: any[]) => {
 
   const start = normalized[0];
   const end = normalized.length === 1 ? normalized[0] : normalized[normalized.length - 1];
-  return [normalizeDateBetweenBoundary(start, 'start'), normalizeDateBetweenBoundary(end, 'end')];
+  const boundaryOptions = {
+    ...options,
+    useDefaultDateBoundary: shouldApplyDefaultDateBoundary(start, end, options),
+  };
+  return [
+    normalizeDateBetweenBoundary(start, 'start', boundaryOptions),
+    normalizeDateBetweenBoundary(end, 'end', boundaryOptions),
+  ];
+};
+
+export const shouldUseDefaultDateBoundary = (fieldSchema?: any) => {
+  if (!fieldSchema) {
+    return false;
+  }
+  const component = fieldSchema['x-component'] || fieldSchema['x-component-props']?.component;
+  return component === 'DatePicker.RangePicker';
 };
 
 export const transformToFilter = (
@@ -236,6 +298,7 @@ export const transformToFilter = (
         const defKey = key;
         let value = _.get(values, key);
         const collectionField = getCollectionJoinField(`${collectionName}.${key}`);
+        const currentFieldSchema = findSchemaByName(getFilterSchemaRoot(fieldSchema), defKey);
         const operator = resolveFilterOperator(fieldSchema, defKey, operators, getOperatorList, collectionField);
         if (collectionField?.target) {
           value = getValuesByPath(value, collectionField.targetKey || 'id');
@@ -262,7 +325,9 @@ export const transformToFilter = (
           }
         } else if (operator === '$dateBetween') {
           if (Array.isArray(value)) {
-            value = normalizeDateBetweenValue(value);
+            value = normalizeDateBetweenValue(value, {
+              useDefaultDateBoundary: shouldUseDefaultDateBoundary(currentFieldSchema),
+            });
             if (!value) {
               return null;
             }

--- a/packages/client/src/filter-provider/utils.ts
+++ b/packages/client/src/filter-provider/utils.ts
@@ -177,7 +177,7 @@ const normalizeDateBetweenBoundary = (value: any, boundary: 'start' | 'end') => 
   return (boundary === 'start' ? m.startOf('day') : m.endOf('day')).toISOString();
 };
 
-const normalizeDateBetweenValue = (value: any[]) => {
+export const normalizeDateBetweenValue = (value: any[]) => {
   const normalized = value.filter(Boolean);
   if (normalized.length === 0) {
     return null;

--- a/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
+++ b/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
@@ -224,4 +224,49 @@ describe('Filter', () => {
       ],
     });
   });
+
+  it('keeps array custom filter values for array-valued operators', () => {
+    const condition = getCustomCondition(
+      { date: ['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.000Z'] },
+      {
+        'x-filter-rules': {
+          $and: [
+            {
+              $or: [
+                {
+                  date_pay: {
+                    $dateBetween: '{{$nFilter.date}}',
+                  },
+                },
+                {
+                  date_receive: {
+                    $dateBetween: '{{$nFilter.date}}',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    );
+
+    expect(condition).toEqual({
+      $and: [
+        {
+          $or: [
+            {
+              date_pay: {
+                $dateBetween: ['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.000Z'],
+              },
+            },
+            {
+              date_receive: {
+                $dateBetween: ['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.000Z'],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
+++ b/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, screen, userEvent, waitFor, within } from '@tachybase/test/client';
 
+import dayjs from 'dayjs';
+
 import App2 from '../demos/demo2';
 import App3 from '../demos/demo3';
 import App4 from '../demos/demo4';
@@ -225,9 +227,13 @@ describe('Filter', () => {
     });
   });
 
-  it('keeps array custom filter values for array-valued operators', () => {
+  it('normalizes array custom filter values for date-between operators', () => {
+    const start = '2026-05-01T00:00:00.000Z';
+    const end = '2026-05-19T23:59:59.000Z';
+    const localStart = start.replace(/Z$/, '');
+    const localEnd = end.replace(/Z$/, '');
     const condition = getCustomCondition(
-      { date: ['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.000Z'] },
+      { date: [start, end] },
       {
         'x-filter-rules': {
           $and: [
@@ -256,12 +262,18 @@ describe('Filter', () => {
           $or: [
             {
               date_pay: {
-                $dateBetween: ['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.000Z'],
+                $dateBetween: [
+                  dayjs(localStart).startOf('day').toISOString(),
+                  dayjs(localEnd).endOf('day').toISOString(),
+                ],
               },
             },
             {
               date_receive: {
-                $dateBetween: ['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.000Z'],
+                $dateBetween: [
+                  dayjs(localStart).startOf('day').toISOString(),
+                  dayjs(localEnd).endOf('day').toISOString(),
+                ],
               },
             },
           ],

--- a/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
+++ b/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
@@ -227,9 +227,56 @@ describe('Filter', () => {
     });
   });
 
-  it('normalizes array custom filter values for date-between operators', () => {
-    const start = '2026-05-01T00:00:00.000Z';
-    const end = '2026-05-19T23:59:59.000Z';
+  it('normalizes date-only custom filter values to full-day boundaries', () => {
+    const start = '2026-05-01';
+    const end = '2026-05-19';
+    const condition = getCustomCondition(
+      { date: [start, end] },
+      {
+        'x-filter-rules': {
+          $and: [
+            {
+              $or: [
+                {
+                  date_pay: {
+                    $dateBetween: '{{$nFilter.date}}',
+                  },
+                },
+                {
+                  date_receive: {
+                    $dateBetween: '{{$nFilter.date}}',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    );
+
+    expect(condition).toEqual({
+      $and: [
+        {
+          $or: [
+            {
+              date_pay: {
+                $dateBetween: [dayjs(start).startOf('day').toISOString(), dayjs(end).endOf('day').toISOString()],
+              },
+            },
+            {
+              date_receive: {
+                $dateBetween: [dayjs(start).startOf('day').toISOString(), dayjs(end).endOf('day').toISOString()],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('preserves explicit time points for date-between custom filter values', () => {
+    const start = '2026-05-01T08:30:00.000Z';
+    const end = '2026-05-19T18:45:00.000Z';
     const localStart = start.replace(/Z$/, '');
     const localEnd = end.replace(/Z$/, '');
     const condition = getCustomCondition(
@@ -262,18 +309,12 @@ describe('Filter', () => {
           $or: [
             {
               date_pay: {
-                $dateBetween: [
-                  dayjs(localStart).startOf('day').toISOString(),
-                  dayjs(localEnd).endOf('day').toISOString(),
-                ],
+                $dateBetween: [dayjs(localStart).toISOString(), dayjs(localEnd).toISOString()],
               },
             },
             {
               date_receive: {
-                $dateBetween: [
-                  dayjs(localStart).startOf('day').toISOString(),
-                  dayjs(localEnd).endOf('day').toISOString(),
-                ],
+                $dateBetween: [dayjs(localStart).toISOString(), dayjs(localEnd).toISOString()],
               },
             },
           ],

--- a/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
+++ b/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
@@ -178,4 +178,50 @@ describe('Filter', () => {
       ],
     });
   });
+
+  it('expands array custom filter values into alternative conditions', () => {
+    const condition = getCustomCondition(
+      { type: ['1', '2'] },
+      {
+        'x-filter-rules': {
+          $and: [
+            {
+              category: {
+                $eq: '3',
+              },
+            },
+            {
+              id: {
+                $eq: '{{$nFilter.type}}',
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(condition).toEqual({
+      $and: [
+        {
+          category: {
+            $eq: '3',
+          },
+        },
+        {
+          $or: [
+            {
+              id: {
+                $eq: '1',
+              },
+            },
+            {
+              id: {
+                $eq: '2',
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
+++ b/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
@@ -227,7 +227,66 @@ describe('Filter', () => {
     });
   });
 
-  it('normalizes date-only custom filter values to full-day boundaries', () => {
+  it('normalizes date-only custom range picker values to full-day boundaries', () => {
+    const start = '2026-05-01T00:00:00.000Z';
+    const end = '2026-05-19T23:59:59.999Z';
+    const condition = getCustomCondition(
+      { date: [start, end] },
+      {
+        properties: {
+          '__custom.date': {
+            name: '__custom.date',
+            'x-component': 'DatePicker.RangePicker',
+          },
+        },
+        'x-filter-rules': {
+          $and: [
+            {
+              $or: [
+                {
+                  date_pay: {
+                    $dateBetween: '{{$nFilter.date}}',
+                  },
+                },
+                {
+                  date_receive: {
+                    $dateBetween: '{{$nFilter.date}}',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    );
+
+    expect(condition).toEqual({
+      $and: [
+        {
+          $or: [
+            {
+              date_pay: {
+                $dateBetween: [
+                  dayjs(start.replace(/Z$/, '')).startOf('day').toISOString(),
+                  dayjs(end.replace(/Z$/, '')).endOf('day').toISOString(),
+                ],
+              },
+            },
+            {
+              date_receive: {
+                $dateBetween: [
+                  dayjs(start.replace(/Z$/, '')).startOf('day').toISOString(),
+                  dayjs(end.replace(/Z$/, '')).endOf('day').toISOString(),
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('normalizes date-only custom filter string values to full-day boundaries', () => {
     const start = '2026-05-01';
     const end = '2026-05-19';
     const condition = getCustomCondition(
@@ -277,11 +336,18 @@ describe('Filter', () => {
   it('preserves explicit time points for date-between custom filter values', () => {
     const start = '2026-05-01T08:30:00.000Z';
     const end = '2026-05-19T18:45:00.000Z';
-    const localStart = start.replace(/Z$/, '');
-    const localEnd = end.replace(/Z$/, '');
     const condition = getCustomCondition(
       { date: [start, end] },
       {
+        properties: {
+          '__custom.date': {
+            name: '__custom.date',
+            'x-component': 'DatePicker.RangePicker',
+            'x-component-props': {
+              showTime: true,
+            },
+          },
+        },
         'x-filter-rules': {
           $and: [
             {
@@ -309,15 +375,53 @@ describe('Filter', () => {
           $or: [
             {
               date_pay: {
-                $dateBetween: [dayjs(localStart).toISOString(), dayjs(localEnd).toISOString()],
+                $dateBetween: [dayjs(start).toISOString(), dayjs(end).toISOString()],
               },
             },
             {
               date_receive: {
-                $dateBetween: [dayjs(localStart).toISOString(), dayjs(localEnd).toISOString()],
+                $dateBetween: [dayjs(start).toISOString(), dayjs(end).toISOString()],
               },
             },
           ],
+        },
+      ],
+    });
+  });
+
+  it('preserves explicit midnight points for date-between custom filter values', () => {
+    const start = '2026-05-01T00:00:00.000Z';
+    const end = '2026-05-19T00:00:00.000Z';
+    const condition = getCustomCondition(
+      { date: [start, end] },
+      {
+        properties: {
+          '__custom.date': {
+            name: '__custom.date',
+            'x-component': 'DatePicker.RangePicker',
+            'x-component-props': {
+              showTime: true,
+            },
+          },
+        },
+        'x-filter-rules': {
+          $and: [
+            {
+              date_pay: {
+                $dateBetween: '{{$nFilter.date}}',
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(condition).toEqual({
+      $and: [
+        {
+          date_pay: {
+            $dateBetween: [dayjs(start).toISOString(), dayjs(end).toISOString()],
+          },
         },
       ],
     });

--- a/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -6,7 +6,11 @@ import { useTranslation } from 'react-i18next';
 
 import { useBlockRequestContext } from '../../../block-provider';
 import { useCollection_deprecated, useCollectionManager_deprecated } from '../../../collection-manager';
-import { FILTER_OPERATORS_WITH_ARRAY_VALUES, mergeFilter } from '../../../filter-provider/utils';
+import {
+  FILTER_OPERATORS_WITH_ARRAY_VALUES,
+  mergeFilter,
+  normalizeDateBetweenValue,
+} from '../../../filter-provider/utils';
 import { useDataLoadingMode } from '../../../modules/blocks/data-blocks/details-multi/setDataLoadingModeSettingsItem';
 import { hasDuplicateKeys } from './utils';
 
@@ -165,9 +169,20 @@ const getCustomFilterValue = (items, key) => {
   return arrayItems.length ? arrayItems : undefined;
 };
 
+const normalizeCustomDateBetweenValue = (value) => {
+  return normalizeDateBetweenValue(
+    value.map((item) => (typeof item === 'string' ? item.replace(/Z$/, '').replace(/[+-]\d\d:\d\d$/, '') : item)),
+  );
+};
+
 const expandArrayValueFilter = (filterSchemaItem, filterKey, value, customFlat) => {
   const pathParts = filterKey.split('.');
   const operator = pathParts.pop();
+  if (operator === '$dateBetween' && Array.isArray(value)) {
+    filterSchemaItem[filterKey] = normalizeCustomDateBetweenValue(value);
+    return;
+  }
+
   if (!Array.isArray(value) || FILTER_OPERATORS_WITH_ARRAY_VALUES.has(operator || '')) {
     filterSchemaItem[filterKey] = value;
     return;

--- a/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -10,6 +10,7 @@ import {
   FILTER_OPERATORS_WITH_ARRAY_VALUES,
   mergeFilter,
   normalizeDateBetweenValue,
+  shouldUseDefaultDateBoundary,
 } from '../../../filter-provider/utils';
 import { useDataLoadingMode } from '../../../modules/blocks/data-blocks/details-multi/setDataLoadingModeSettingsItem';
 import { hasDuplicateKeys } from './utils';
@@ -169,17 +170,43 @@ const getCustomFilterValue = (items, key) => {
   return arrayItems.length ? arrayItems : undefined;
 };
 
-const normalizeCustomDateBetweenValue = (value) => {
-  return normalizeDateBetweenValue(
-    value.map((item) => (typeof item === 'string' ? item.replace(/Z$/, '').replace(/[+-]\d\d:\d\d$/, '') : item)),
-  );
+const findCustomFieldSchemaInTree = (schema, key) => {
+  if (!schema) {
+    return null;
+  }
+  if (schema.name === `__custom.${key}` || schema.name === key) {
+    return schema;
+  }
+  const properties = schema.properties || {};
+  for (const propertyKey of Object.keys(properties)) {
+    if (propertyKey === `__custom.${key}` || propertyKey === key) {
+      return properties[propertyKey];
+    }
+    const found = findCustomFieldSchemaInTree(properties[propertyKey], key);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
 };
 
-const expandArrayValueFilter = (filterSchemaItem, filterKey, value, customFlat) => {
+const findCustomFieldSchema = (schema, key) => {
+  let current = schema;
+  while (current) {
+    const found = findCustomFieldSchemaInTree(current, key);
+    if (found) {
+      return found;
+    }
+    current = current.parent;
+  }
+  return null;
+};
+
+const expandArrayValueFilter = (filterSchemaItem, filterKey, value, customFlat, options: any = {}) => {
   const pathParts = filterKey.split('.');
   const operator = pathParts.pop();
   if (operator === '$dateBetween' && Array.isArray(value)) {
-    filterSchemaItem[filterKey] = normalizeCustomDateBetweenValue(value);
+    filterSchemaItem[filterKey] = normalizeDateBetweenValue(value, options);
     return;
   }
 
@@ -218,7 +245,10 @@ export const getCustomCondition: any = (filter, fieldSchema, customFlat = flat) 
         if (!match) {
           continue;
         }
-        expandArrayValueFilter(filterSchemaItem, filterKey, getCustomFilterValue(items, match[1]), customFlat);
+        const customFieldSchema = findCustomFieldSchema(fieldSchema, match[1]);
+        expandArrayValueFilter(filterSchemaItem, filterKey, getCustomFilterValue(items, match[1]), customFlat, {
+          useDefaultDateBoundary: shouldUseDefaultDateBoundary(customFieldSchema),
+        });
       }
       for (const item in filterSchemaItem) {
         if (!filterSchemaItem[item] || filterSchemaItem[item].includes('$nFilter')) {

--- a/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useBlockRequestContext } from '../../../block-provider';
 import { useCollection_deprecated, useCollectionManager_deprecated } from '../../../collection-manager';
-import { mergeFilter } from '../../../filter-provider/utils';
+import { FILTER_OPERATORS_WITH_ARRAY_VALUES, mergeFilter } from '../../../filter-provider/utils';
 import { useDataLoadingMode } from '../../../modules/blocks/data-blocks/details-multi/setDataLoadingModeSettingsItem';
 import { hasDuplicateKeys } from './utils';
 
@@ -152,6 +152,42 @@ const isEmpty = (obj) => {
 
 const CUSTOM_FILTER_VARIABLE_REGEXP = /^\{\{\$nFilter\.([^}]+)\}\}$/;
 
+const getCustomFilterValue = (items, key) => {
+  if (key in items) {
+    return items[key];
+  }
+
+  const arrayItems = Object.keys(items)
+    .filter((itemKey) => /^\d+$/.test(itemKey.slice(key.length + 1)) && itemKey.startsWith(`${key}.`))
+    .sort((a, b) => Number(a.slice(key.length + 1)) - Number(b.slice(key.length + 1)))
+    .map((itemKey) => items[itemKey]);
+
+  return arrayItems.length ? arrayItems : undefined;
+};
+
+const expandArrayValueFilter = (filterSchemaItem, filterKey, value, customFlat) => {
+  const pathParts = filterKey.split('.');
+  const operator = pathParts.pop();
+  if (!Array.isArray(value) || FILTER_OPERATORS_WITH_ARRAY_VALUES.has(operator || '')) {
+    filterSchemaItem[filterKey] = value;
+    return;
+  }
+
+  let branchEndIndex = -1;
+  for (let index = pathParts.length - 2; index >= 0; index--) {
+    if (['$and', '$or'].includes(pathParts[index]) && /^\d+$/.test(pathParts[index + 1])) {
+      branchEndIndex = index;
+      break;
+    }
+  }
+
+  const branchPath = branchEndIndex >= 0 ? pathParts.slice(0, branchEndIndex + 2).join('.') : '';
+  const fieldPath = pathParts.slice(branchEndIndex + 2).join('.');
+  const conditions = value.map((item) => customFlat.unflatten({ [`${fieldPath}.${operator}`]: item }));
+  delete filterSchemaItem[filterKey];
+  filterSchemaItem[branchPath ? `${branchPath}.$or` : '$or'] = conditions;
+};
+
 export const getCustomCondition: any = (filter, fieldSchema, customFlat = flat) => {
   const filterSchema = fieldSchema ? fieldSchema['x-filter-rules'] : '';
   const filterSchemaItem = customFlat(filterSchema || '') as any;
@@ -167,7 +203,7 @@ export const getCustomCondition: any = (filter, fieldSchema, customFlat = flat) 
         if (!match) {
           continue;
         }
-        filterSchemaItem[filterKey] = items[match[1]];
+        expandArrayValueFilter(filterSchemaItem, filterKey, getCustomFilterValue(items, match[1]), customFlat);
       }
       for (const item in filterSchemaItem) {
         if (!filterSchemaItem[item] || filterSchemaItem[item].includes('$nFilter')) {

--- a/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -158,7 +158,7 @@ const getCustomFilterValue = (items, key) => {
   }
 
   const arrayItems = Object.keys(items)
-    .filter((itemKey) => /^\d+$/.test(itemKey.slice(key.length + 1)) && itemKey.startsWith(`${key}.`))
+    .filter((itemKey) => itemKey.startsWith(`${key}.`) && /^\d+$/.test(itemKey.slice(key.length + 1)))
     .sort((a, b) => Number(a.slice(key.length + 1)) - Number(b.slice(key.length + 1)))
     .map((itemKey) => items[itemKey]);
 


### PR DESCRIPTION
Preserve literal custom filter values, expand array selections into alternative conditions, and unify date range normalization between ordinary and custom filters so date-only ranges and explicit datetime values are handled consistently.
