### PR TITLE
fix(client): datepicker range filter semantics

### DIFF
--- a/packages/client/src/filter-provider/__tests__/transformToFilter.ts
+++ b/packages/client/src/filter-provider/__tests__/transformToFilter.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 
+import { mapRangePicker } from '../../schema-component/antd/date-picker/util';
 import { transformToFilter } from '../utils';
 
 // TODO: 前端测试报错解决之后，把该文件重命名为 transformToFilter.test.ts
@@ -102,11 +103,19 @@ describe('transformToFilter', () => {
     });
   });
 
-  it('should preserve explicit $dateBetween times for datetime range fields', () => {
-    const start = '2026-04-13T00:00:00.000Z';
-    const end = '2026-04-19T18:45:00.000Z';
+  it('should use DatePicker range mode metadata instead of boundary strings when normalizing date ranges', () => {
+    let rangeValue: any[];
+    const dateOnlyMapped = mapRangePicker()({
+      showTime: false,
+      utc: true,
+      onChange: (nextValue: any[]) => {
+        rangeValue = nextValue;
+      },
+    });
+    dateOnlyMapped.onChange([dayjs('2026-05-01 00:00:00'), dayjs('2026-05-19 00:00:00')]);
+
     const values = {
-      createdAt: [start, end],
+      createdAt: rangeValue,
     };
 
     const fieldSchema = {
@@ -133,7 +142,56 @@ describe('transformToFilter', () => {
       $and: [
         {
           createdAt: {
-            $dateBetween: [dayjs(start).toISOString(), dayjs(end).toISOString()],
+            $dateBetween: [
+              dayjs('2026-05-01 00:00:00').startOf('day').toISOString(),
+              dayjs('2026-05-19 23:59:59.999').endOf('day').toISOString(),
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it('should preserve explicit boundary-looking times from datetime range fields', () => {
+    let rangeValue: any[];
+    const datetimeMapped = mapRangePicker()({
+      showTime: true,
+      utc: true,
+      onChange: (nextValue: any[]) => {
+        rangeValue = nextValue;
+      },
+    });
+    datetimeMapped.onChange([dayjs('2026-05-01 00:00:00'), dayjs('2026-05-19 23:59:59')]);
+
+    const values = {
+      createdAt: rangeValue,
+    };
+
+    const fieldSchema = {
+      'x-filter-operators': {
+        createdAt: '$dateBetween',
+      },
+      properties: {
+        createdAt: {
+          name: 'createdAt',
+          'x-component-props': {
+            component: 'DatePicker.RangePicker',
+            showTime: true,
+          },
+        },
+      },
+    };
+
+    const getField = () => ({
+      targetKey: undefined,
+      interface: 'createdAt',
+    });
+
+    expect(transformToFilter(values, fieldSchema as any, getField, 'receipt')).toEqual({
+      $and: [
+        {
+          createdAt: {
+            $dateBetween: [dayjs(rangeValue[0]).toISOString(), dayjs(rangeValue[1]).toISOString()],
           },
         },
       ],

--- a/packages/client/src/filter-provider/__tests__/transformToFilter.ts
+++ b/packages/client/src/filter-provider/__tests__/transformToFilter.ts
@@ -96,7 +96,7 @@ describe('transformToFilter', () => {
       $and: [
         {
           createdAt: {
-            $dateBetween: [start, end],
+            $dateBetween: [dayjs(start).startOf('day').toISOString(), dayjs(end).endOf('day').toISOString()],
           },
         },
       ],
@@ -142,14 +142,17 @@ describe('transformToFilter', () => {
       $and: [
         {
           createdAt: {
-            $dateBetween: rangeValue,
+            $dateBetween: [
+              dayjs('2026-05-01 00:00:00').startOf('day').toISOString(),
+              dayjs('2026-05-19 23:59:59.999').endOf('day').toISOString(),
+            ],
           },
         },
       ],
     });
   });
 
-  it('should preserve unmarked retained date-only boundaries for ordinary range fields after enabling time', () => {
+  it('should normalize unmarked retained date-only boundaries for ordinary range fields after enabling time', () => {
     let rangeValue: any[];
     const dateOnlyMapped = mapRangePicker()({
       showTime: false,
@@ -189,7 +192,46 @@ describe('transformToFilter', () => {
       $and: [
         {
           createdAt: {
-            $dateBetween: copiedRangeValue,
+            $dateBetween: [
+              dayjs('2026-05-01 00:00:00').startOf('day').toISOString(),
+              dayjs('2026-05-19 23:59:59.999').endOf('day').toISOString(),
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it('should preserve converted ordinary retained date-only boundaries after enabling time', () => {
+    const values = {
+      createdAt: ['2026-04-30T16:00:00.000Z', '2026-05-19T15:59:59.999Z'],
+    };
+
+    const fieldSchema = {
+      'x-filter-operators': {
+        createdAt: '$dateBetween',
+      },
+      properties: {
+        createdAt: {
+          name: 'createdAt',
+          'x-component-props': {
+            component: 'DatePicker.RangePicker',
+            showTime: true,
+          },
+        },
+      },
+    };
+
+    const getField = () => ({
+      targetKey: undefined,
+      interface: 'createdAt',
+    });
+
+    expect(transformToFilter(values, fieldSchema as any, getField, 'receipt')).toEqual({
+      $and: [
+        {
+          createdAt: {
+            $dateBetween: values.createdAt,
           },
         },
       ],

--- a/packages/client/src/filter-provider/__tests__/transformToFilter.ts
+++ b/packages/client/src/filter-provider/__tests__/transformToFilter.ts
@@ -96,7 +96,7 @@ describe('transformToFilter', () => {
       $and: [
         {
           createdAt: {
-            $dateBetween: [dayjs(start).toISOString(), dayjs(end).toISOString()],
+            $dateBetween: [start, end],
           },
         },
       ],
@@ -142,10 +142,54 @@ describe('transformToFilter', () => {
       $and: [
         {
           createdAt: {
-            $dateBetween: [
-              dayjs('2026-05-01 00:00:00').startOf('day').toISOString(),
-              dayjs('2026-05-19 23:59:59.999').endOf('day').toISOString(),
-            ],
+            $dateBetween: rangeValue,
+          },
+        },
+      ],
+    });
+  });
+
+  it('should preserve unmarked retained date-only boundaries for ordinary range fields after enabling time', () => {
+    let rangeValue: any[];
+    const dateOnlyMapped = mapRangePicker()({
+      showTime: false,
+      utc: true,
+      onChange: (nextValue: any[]) => {
+        rangeValue = nextValue;
+      },
+    });
+    dateOnlyMapped.onChange([dayjs('2026-05-01 00:00:00'), dayjs('2026-05-19 00:00:00')]);
+
+    const copiedRangeValue = [rangeValue[0], rangeValue[1]];
+    const values = {
+      createdAt: copiedRangeValue,
+    };
+
+    const fieldSchema = {
+      'x-filter-operators': {
+        createdAt: '$dateBetween',
+      },
+      properties: {
+        createdAt: {
+          name: 'createdAt',
+          'x-component-props': {
+            component: 'DatePicker.RangePicker',
+            showTime: true,
+          },
+        },
+      },
+    };
+
+    const getField = () => ({
+      targetKey: undefined,
+      interface: 'createdAt',
+    });
+
+    expect(transformToFilter(values, fieldSchema as any, getField, 'receipt')).toEqual({
+      $and: [
+        {
+          createdAt: {
+            $dateBetween: copiedRangeValue,
           },
         },
       ],

--- a/packages/client/src/filter-provider/utils.ts
+++ b/packages/client/src/filter-provider/utils.ts
@@ -14,7 +14,11 @@ import {
   useCollectionManager_deprecated,
 } from '../collection-manager';
 import { removeNullCondition } from '../schema-component';
-import { getRangeValueMode } from '../schema-component/antd/date-picker/util';
+import {
+  isDatePickerDefaultRangeBoundaryValue,
+  resolveDatePickerRangeValueInfo,
+  type DatePickerRangeValueMode,
+} from '../schema-component/antd/date-picker/util';
 import {
   findFilterOperators,
   getDefaultFilterOperatorValue,
@@ -175,6 +179,16 @@ const resolveFilterOperator = (
 
 type NormalizeDateBetweenOptions = {
   useDefaultDateBoundary?: boolean;
+  valueMode?: DatePickerRangeValueMode;
+  preferDateBoundaryFallback?: boolean;
+};
+
+const getDatePickerComponent = (fieldSchema?: any) => {
+  return fieldSchema?.['x-component'] || fieldSchema?.['x-component-props']?.component;
+};
+
+const getDatePickerShowTime = (fieldSchema?: any) => {
+  return fieldSchema?.['x-component-props']?.showTime;
 };
 
 const isDateOnlyString = (value: any) => {
@@ -185,40 +199,32 @@ const hasExplicitTime = (value: any) => {
   return typeof value === 'string' && /[T\s]\d{2}:\d{2}/.test(value);
 };
 
-const isDefaultDateBoundaryValue = (value: any, boundary: 'start' | 'end') => {
-  if (isDateOnlyString(value)) {
-    return true;
-  }
-  if (typeof value !== 'string') {
-    return false;
-  }
-  const match = value.match(/^\d{4}-\d{2}-\d{2}[T\s](\d{2}:\d{2}:\d{2})(?:\.\d{3})?(?:Z|[+-]\d\d:\d\d)?$/);
-  if (!match) {
-    return false;
-  }
-  return boundary === 'start' ? match[1] === '00:00:00' : match[1] === '23:59:59';
-};
-
-const normalizeDefaultDateBoundaryInput = (value: any) => {
-  if (typeof value !== 'string') {
-    return value;
-  }
-  return value.replace(/Z$/, '').replace(/[+-]\d\d:\d\d$/, '');
-};
-
 const normalizeDateBetweenBoundary = (
   value: any,
   boundary: 'start' | 'end',
   options: NormalizeDateBetweenOptions = {},
 ) => {
-  const rawValue = options.useDefaultDateBoundary ? normalizeDefaultDateBoundaryInput(value) : value;
-  const m = dayjs(rawValue);
+  const m = dayjs(value);
   if (!m.isValid()) {
     return value;
   }
-  if (!options.useDefaultDateBoundary && hasExplicitTime(rawValue) && !isDateOnlyString(rawValue)) {
+
+  if (isDateOnlyString(value)) {
+    return (boundary === 'start' ? m.startOf('day') : m.endOf('day')).toISOString();
+  }
+
+  if (options.valueMode === 'date' && isDatePickerDefaultRangeBoundaryValue(value, boundary)) {
     return m.toISOString();
   }
+
+  if (hasExplicitTime(value)) {
+    return m.toISOString();
+  }
+
+  if (!options.useDefaultDateBoundary) {
+    return m.toISOString();
+  }
+
   return (boundary === 'start' ? m.startOf('day') : m.endOf('day')).toISOString();
 };
 
@@ -228,10 +234,10 @@ const shouldApplyDefaultDateBoundary = (
   value: any[],
   options: NormalizeDateBetweenOptions = {},
 ) => {
-  if (getRangeValueMode(value) === 'datetime') {
+  if (options.valueMode === 'datetime') {
     return false;
   }
-  if (getRangeValueMode(value) === 'date') {
+  if (options.valueMode === 'date') {
     return true;
   }
   if (!options.useDefaultDateBoundary) {
@@ -240,7 +246,11 @@ const shouldApplyDefaultDateBoundary = (
   if (isDateOnlyString(start) || isDateOnlyString(end)) {
     return true;
   }
-  return isDefaultDateBoundaryValue(start, 'start') && isDefaultDateBoundaryValue(end, 'end');
+  return (
+    options.preferDateBoundaryFallback &&
+    isDatePickerDefaultRangeBoundaryValue(start, 'start') &&
+    isDatePickerDefaultRangeBoundaryValue(end, 'end')
+  );
 };
 
 export const normalizeDateBetweenValue = (value: any[], options: NormalizeDateBetweenOptions = {}) => {
@@ -262,11 +272,7 @@ export const normalizeDateBetweenValue = (value: any[], options: NormalizeDateBe
 };
 
 export const shouldUseDefaultDateBoundary = (fieldSchema?: any) => {
-  if (!fieldSchema) {
-    return false;
-  }
-  const component = fieldSchema['x-component'] || fieldSchema['x-component-props']?.component;
-  return component === 'DatePicker.RangePicker';
+  return getDatePickerComponent(fieldSchema) === 'DatePicker.RangePicker';
 };
 
 export const transformToFilter = (
@@ -337,8 +343,15 @@ export const transformToFilter = (
           }
         } else if (operator === '$dateBetween') {
           if (Array.isArray(value)) {
+            const valueInfo = resolveDatePickerRangeValueInfo(value, {
+              component: getDatePickerComponent(currentFieldSchema),
+              showTime: getDatePickerShowTime(currentFieldSchema),
+              preferDateBoundaryFallback: shouldUseDefaultDateBoundary(currentFieldSchema),
+            });
             value = normalizeDateBetweenValue(value, {
               useDefaultDateBoundary: shouldUseDefaultDateBoundary(currentFieldSchema),
+              valueMode: valueInfo.mode,
+              preferDateBoundaryFallback: valueInfo.source === 'retained-date-boundary',
             });
             if (!value) {
               return null;

--- a/packages/client/src/filter-provider/utils.ts
+++ b/packages/client/src/filter-provider/utils.ts
@@ -14,6 +14,7 @@ import {
   useCollectionManager_deprecated,
 } from '../collection-manager';
 import { removeNullCondition } from '../schema-component';
+import { getRangeValueMode } from '../schema-component/antd/date-picker/util';
 import {
   findFilterOperators,
   getDefaultFilterOperatorValue,
@@ -221,7 +222,18 @@ const normalizeDateBetweenBoundary = (
   return (boundary === 'start' ? m.startOf('day') : m.endOf('day')).toISOString();
 };
 
-const shouldApplyDefaultDateBoundary = (start: any, end: any, options: NormalizeDateBetweenOptions = {}) => {
+const shouldApplyDefaultDateBoundary = (
+  start: any,
+  end: any,
+  value: any[],
+  options: NormalizeDateBetweenOptions = {},
+) => {
+  if (getRangeValueMode(value) === 'datetime') {
+    return false;
+  }
+  if (getRangeValueMode(value) === 'date') {
+    return true;
+  }
   if (!options.useDefaultDateBoundary) {
     return false;
   }
@@ -241,7 +253,7 @@ export const normalizeDateBetweenValue = (value: any[], options: NormalizeDateBe
   const end = normalized.length === 1 ? normalized[0] : normalized[normalized.length - 1];
   const boundaryOptions = {
     ...options,
-    useDefaultDateBoundary: shouldApplyDefaultDateBoundary(start, end, options),
+    useDefaultDateBoundary: shouldApplyDefaultDateBoundary(start, end, value, options),
   };
   return [
     normalizeDateBetweenBoundary(start, 'start', boundaryOptions),

--- a/packages/client/src/filter-provider/utils.ts
+++ b/packages/client/src/filter-provider/utils.ts
@@ -18,6 +18,7 @@ import {
   isDatePickerDefaultRangeBoundaryValue,
   resolveDatePickerRangeValueInfo,
   type DatePickerRangeValueMode,
+  type DatePickerRangeValueSource,
 } from '../schema-component/antd/date-picker/util';
 import {
   findFilterOperators,
@@ -180,6 +181,7 @@ const resolveFilterOperator = (
 type NormalizeDateBetweenOptions = {
   useDefaultDateBoundary?: boolean;
   valueMode?: DatePickerRangeValueMode;
+  valueSource?: DatePickerRangeValueSource;
   preferDateBoundaryFallback?: boolean;
 };
 
@@ -199,6 +201,13 @@ const hasExplicitTime = (value: any) => {
   return typeof value === 'string' && /[T\s]\d{2}:\d{2}/.test(value);
 };
 
+const normalizeLocalDateBoundaryInput = (value: any) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  return value.replace(/Z$/, '').replace(/[+-]\d\d:\d\d$/, '');
+};
+
 const normalizeDateBetweenBoundary = (
   value: any,
   boundary: 'start' | 'end',
@@ -213,8 +222,12 @@ const normalizeDateBetweenBoundary = (
     return (boundary === 'start' ? m.startOf('day') : m.endOf('day')).toISOString();
   }
 
-  if (options.valueMode === 'date' && isDatePickerDefaultRangeBoundaryValue(value, boundary)) {
-    return m.toISOString();
+  if (options.valueMode === 'date') {
+    if (options.valueSource === 'retained-local-date-boundary') {
+      return m.toISOString();
+    }
+    const localBoundary = dayjs(normalizeLocalDateBoundaryInput(value));
+    return (boundary === 'start' ? localBoundary.startOf('day') : localBoundary.endOf('day')).toISOString();
   }
 
   if (hasExplicitTime(value)) {
@@ -248,6 +261,7 @@ const shouldApplyDefaultDateBoundary = (
   }
   return (
     options.preferDateBoundaryFallback &&
+    options.valueMode === 'date' &&
     isDatePickerDefaultRangeBoundaryValue(start, 'start') &&
     isDatePickerDefaultRangeBoundaryValue(end, 'end')
   );
@@ -351,6 +365,7 @@ export const transformToFilter = (
             value = normalizeDateBetweenValue(value, {
               useDefaultDateBoundary: shouldUseDefaultDateBoundary(currentFieldSchema),
               valueMode: valueInfo.mode,
+              valueSource: valueInfo.source,
               preferDateBoundaryFallback: valueInfo.source === 'retained-date-boundary',
             });
             if (!value) {

--- a/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
+++ b/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
@@ -156,11 +156,21 @@ describe('mapRangePicker', () => {
     expect(mapped.value[1].format('YYYY-MM-DD')).toBe('2026-01-16');
   });
 
-  test('should keep retained date-only range boundaries as local days after enabling showTime', () => {
+  test('should keep retained date-only range values as local days after enabling showTime', () => {
     vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-480);
 
+    let value: any[];
+    const dateOnlyMapped = mapRangePicker()({
+      showTime: false,
+      utc: true,
+      onChange: (nextValue: any[]) => {
+        value = nextValue;
+      },
+    });
+    dateOnlyMapped.onChange([dayjs('2026-05-01 00:00:00'), dayjs('2026-05-19 00:00:00')]);
+
     const mapped = mapRangePicker()({
-      value: ['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.999Z'],
+      value,
       showTime: true,
       utc: true,
     });

--- a/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
+++ b/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
@@ -179,6 +179,19 @@ describe('mapRangePicker', () => {
     expect(mapped.value[1].format('YYYY-MM-DD HH:mm:ss')).toBe('2026-05-19 23:59:59');
   });
 
+  test('should keep unmarked retained date-only range boundaries as local days after enabling showTime', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-480);
+
+    const mapped = mapRangePicker()({
+      value: ['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.999Z'],
+      showTime: true,
+      utc: true,
+    });
+
+    expect(mapped.value[0].format('YYYY-MM-DD HH:mm:ss')).toBe('2026-05-01 00:00:00');
+    expect(mapped.value[1].format('YYYY-MM-DD HH:mm:ss')).toBe('2026-05-19 23:59:59');
+  });
+
   test('should preserve explicit datetime range values after enabling showTime', () => {
     vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-480);
 

--- a/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
+++ b/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
@@ -3,7 +3,7 @@ import { str2moment } from '@tego/client';
 import dayjs from 'dayjs';
 import { vi } from 'vitest';
 
-import { mapRangePicker, moment2str } from '../util';
+import { mapRangePicker, moment2str, resolveDatePickerRangeValueInfo } from '../util';
 
 describe('str2moment', () => {
   describe('string value', () => {
@@ -143,6 +143,62 @@ describe('moment2str', () => {
 });
 
 describe('mapRangePicker', () => {
+  test('should resolve retained date range mode from live metadata first', () => {
+    let value: any[];
+    const dateOnlyMapped = mapRangePicker()({
+      showTime: false,
+      utc: true,
+      onChange: (nextValue: any[]) => {
+        value = nextValue;
+      },
+    });
+    dateOnlyMapped.onChange([dayjs('2026-05-01 00:00:00'), dayjs('2026-05-19 00:00:00')]);
+
+    expect(resolveDatePickerRangeValueInfo(value, { showTime: true })).toEqual({
+      mode: 'date',
+      source: 'metadata',
+    });
+  });
+
+  test('should resolve datetime range mode from live metadata before boundary fallback', () => {
+    let value: any[];
+    const datetimeMapped = mapRangePicker()({
+      showTime: true,
+      utc: true,
+      onChange: (nextValue: any[]) => {
+        value = nextValue;
+      },
+    });
+    datetimeMapped.onChange([dayjs('2026-05-01 00:00:00'), dayjs('2026-05-19 23:59:59')]);
+
+    expect(
+      resolveDatePickerRangeValueInfo(value, {
+        showTime: true,
+        component: 'DatePicker.RangePicker',
+        preferDateBoundaryFallback: true,
+      }),
+    ).toEqual({
+      mode: 'datetime',
+      source: 'metadata',
+    });
+  });
+
+  test('should resolve unmarked retained range boundaries only when fallback is requested', () => {
+    const value = ['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.999Z'];
+
+    expect(resolveDatePickerRangeValueInfo(value, { showTime: true })).toEqual({ source: 'unknown' });
+    expect(
+      resolveDatePickerRangeValueInfo(value, {
+        showTime: true,
+        component: 'DatePicker.RangePicker',
+        preferDateBoundaryFallback: true,
+      }),
+    ).toEqual({
+      mode: 'date',
+      source: 'retained-date-boundary',
+    });
+  });
+
   test('should parse date-only range values with GMT semantics when gmt is not specified', () => {
     vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-480);
 

--- a/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
+++ b/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
@@ -199,6 +199,32 @@ describe('mapRangePicker', () => {
     });
   });
 
+  test('should resolve original and converted retained range boundaries separately', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-480);
+
+    expect(
+      resolveDatePickerRangeValueInfo(['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.999Z'], {
+        showTime: true,
+        component: 'DatePicker.RangePicker',
+        preferDateBoundaryFallback: true,
+      }),
+    ).toEqual({
+      mode: 'date',
+      source: 'retained-date-boundary',
+    });
+
+    expect(
+      resolveDatePickerRangeValueInfo(['2026-04-30T16:00:00.000Z', '2026-05-19T15:59:59.999Z'], {
+        showTime: true,
+        component: 'DatePicker.RangePicker',
+        preferDateBoundaryFallback: true,
+      }),
+    ).toEqual({
+      mode: 'date',
+      source: 'retained-local-date-boundary',
+    });
+  });
+
   test('should parse date-only range values with GMT semantics when gmt is not specified', () => {
     vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-480);
 
@@ -240,6 +266,19 @@ describe('mapRangePicker', () => {
 
     const mapped = mapRangePicker()({
       value: ['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.999Z'],
+      showTime: true,
+      utc: true,
+    });
+
+    expect(mapped.value[0].format('YYYY-MM-DD HH:mm:ss')).toBe('2026-05-01 00:00:00');
+    expect(mapped.value[1].format('YYYY-MM-DD HH:mm:ss')).toBe('2026-05-19 23:59:59');
+  });
+
+  test('should keep converted ordinary retained date-only range boundaries as local days after enabling showTime', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-480);
+
+    const mapped = mapRangePicker()({
+      value: ['2026-04-30T16:00:00.000Z', '2026-05-19T15:59:59.999Z'],
       showTime: true,
       utc: true,
     });

--- a/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
+++ b/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
@@ -155,4 +155,30 @@ describe('mapRangePicker', () => {
     expect(mapped.value[0].format('YYYY-MM-DD')).toBe('2026-01-15');
     expect(mapped.value[1].format('YYYY-MM-DD')).toBe('2026-01-16');
   });
+
+  test('should keep retained date-only range boundaries as local days after enabling showTime', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-480);
+
+    const mapped = mapRangePicker()({
+      value: ['2026-05-01T00:00:00.000Z', '2026-05-19T23:59:59.999Z'],
+      showTime: true,
+      utc: true,
+    });
+
+    expect(mapped.value[0].format('YYYY-MM-DD HH:mm:ss')).toBe('2026-05-01 00:00:00');
+    expect(mapped.value[1].format('YYYY-MM-DD HH:mm:ss')).toBe('2026-05-19 23:59:59');
+  });
+
+  test('should preserve explicit datetime range values after enabling showTime', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-480);
+
+    const mapped = mapRangePicker()({
+      value: ['2026-05-01T00:30:00.000Z', '2026-05-19T10:45:00.000Z'],
+      showTime: true,
+      utc: true,
+    });
+
+    expect(mapped.value[0].toISOString()).toBe('2026-05-01T00:30:00.000Z');
+    expect(mapped.value[1].toISOString()).toBe('2026-05-19T10:45:00.000Z');
+  });
 });

--- a/packages/client/src/schema-component/antd/date-picker/util.ts
+++ b/packages/client/src/schema-component/antd/date-picker/util.ts
@@ -46,17 +46,25 @@ export interface Moment2strOptions {
   utc?: boolean;
   picker?: 'year' | 'month' | 'week' | 'quarter';
   value?: any;
+  component?: string;
 }
 
 export const DATE_PICKER_RANGE_VALUE_MODE = Symbol.for('tachybase.datePicker.rangeValueMode');
 
 export type DatePickerRangeValueMode = 'date' | 'datetime';
 
+export type DatePickerRangeValueSource = 'metadata' | 'schema' | 'retained-date-boundary' | 'unknown';
+
+export interface DatePickerRangeValueInfo {
+  mode?: DatePickerRangeValueMode;
+  source: DatePickerRangeValueSource;
+}
+
 export const getRangeValueMode = (value: any): DatePickerRangeValueMode | undefined => {
   return Array.isArray(value) ? value[DATE_PICKER_RANGE_VALUE_MODE] : undefined;
 };
 
-const markRangeValueMode = (value: any[], mode: DatePickerRangeValueMode) => {
+export const markRangeValueMode = (value: any[], mode: DatePickerRangeValueMode) => {
   Object.defineProperty(value, DATE_PICKER_RANGE_VALUE_MODE, {
     configurable: true,
     enumerable: false,
@@ -65,7 +73,7 @@ const markRangeValueMode = (value: any[], mode: DatePickerRangeValueMode) => {
   return value;
 };
 
-const isDefaultRangeBoundaryValue = (value: any, boundary: 'start' | 'end') => {
+export const isDatePickerDefaultRangeBoundaryValue = (value: any, boundary: 'start' | 'end') => {
   if (typeof value !== 'string') {
     return false;
   }
@@ -76,13 +84,33 @@ const isDefaultRangeBoundaryValue = (value: any, boundary: 'start' | 'end') => {
   return boundary === 'start' ? match[1] === '00:00:00' : match[1] === '23:59:59';
 };
 
-const isDefaultRangeBoundaryValuePair = (value: any) => {
+export const isDatePickerDefaultRangeBoundaryPair = (value: any) => {
   return (
     Array.isArray(value) &&
     value.length >= 2 &&
-    isDefaultRangeBoundaryValue(value[0], 'start') &&
-    isDefaultRangeBoundaryValue(value[value.length - 1], 'end')
+    isDatePickerDefaultRangeBoundaryValue(value[0], 'start') &&
+    isDatePickerDefaultRangeBoundaryValue(value[value.length - 1], 'end')
   );
+};
+
+export const resolveDatePickerRangeValueInfo = (
+  value: any,
+  options: { showTime?: boolean; component?: string; preferDateBoundaryFallback?: boolean } = {},
+): DatePickerRangeValueInfo => {
+  const metadataMode = getRangeValueMode(value);
+  if (metadataMode) {
+    return { mode: metadataMode, source: 'metadata' };
+  }
+
+  if (options.component === 'DatePicker.RangePicker' && !options.showTime) {
+    return { mode: 'date', source: 'schema' };
+  }
+
+  if (options.preferDateBoundaryFallback && isDatePickerDefaultRangeBoundaryPair(value)) {
+    return { mode: 'date', source: 'retained-date-boundary' };
+  }
+
+  return { source: 'unknown' };
 };
 
 export const normalizeDatePickerParseOptions = (options: Moment2strOptions = {}) => {
@@ -90,16 +118,16 @@ export const normalizeDatePickerParseOptions = (options: Moment2strOptions = {})
     return options;
   }
 
-  if (
-    options.showTime &&
-    getRangeValueMode(options.value) !== 'date' &&
-    !isDefaultRangeBoundaryValuePair(options.value)
-  ) {
+  const rangeValueInfo = resolveDatePickerRangeValueInfo(options.value, {
+    component: options.component,
+    showTime: options.showTime,
+    preferDateBoundaryFallback: options.component === 'DatePicker.RangePicker',
+  });
+
+  if (options.showTime && rangeValueInfo.mode !== 'date') {
     return options;
   }
 
-  // For date-only values, the write path defaults to GMT strings.
-  // Read path needs the same assumption, otherwise end-of-day values drift into the next local day.
   return {
     ...options,
     gmt: true,
@@ -153,7 +181,10 @@ export const mapRangePicker = function () {
     return {
       ...props,
       format: format,
-      value: str2moment(props.value, normalizeDatePickerParseOptions(props)),
+      value: str2moment(
+        props.value,
+        normalizeDatePickerParseOptions({ ...props, component: 'DatePicker.RangePicker' }),
+      ),
       onChange: (value: Dayjs[]) => {
         if (onChange) {
           onChange(

--- a/packages/client/src/schema-component/antd/date-picker/util.ts
+++ b/packages/client/src/schema-component/antd/date-picker/util.ts
@@ -45,10 +45,35 @@ export interface Moment2strOptions {
   gmt?: boolean;
   utc?: boolean;
   picker?: 'year' | 'month' | 'week' | 'quarter';
+  value?: any;
 }
 
+const isDefaultRangeBoundaryValue = (value: any, boundary: 'start' | 'end') => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const match = value.match(/^\d{4}-\d{2}-\d{2}[T\s](\d{2}:\d{2}:\d{2})(?:\.\d{3})?(?:Z|[+-]\d\d:\d\d)?$/);
+  if (!match) {
+    return false;
+  }
+  return boundary === 'start' ? match[1] === '00:00:00' : match[1] === '23:59:59';
+};
+
+const isDefaultRangeBoundaryValuePair = (value: any) => {
+  return (
+    Array.isArray(value) &&
+    value.length >= 2 &&
+    isDefaultRangeBoundaryValue(value[0], 'start') &&
+    isDefaultRangeBoundaryValue(value[value.length - 1], 'end')
+  );
+};
+
 export const normalizeDatePickerParseOptions = (options: Moment2strOptions = {}) => {
-  if (options.utc === false || options.showTime || typeof options.gmt === 'boolean' || options.picker) {
+  if (options.utc === false || typeof options.gmt === 'boolean' || options.picker) {
+    return options;
+  }
+
+  if (options.showTime && !isDefaultRangeBoundaryValuePair(options.value)) {
     return options;
   }
 

--- a/packages/client/src/schema-component/antd/date-picker/util.ts
+++ b/packages/client/src/schema-component/antd/date-picker/util.ts
@@ -48,24 +48,21 @@ export interface Moment2strOptions {
   value?: any;
 }
 
-const isDefaultRangeBoundaryValue = (value: any, boundary: 'start' | 'end') => {
-  if (typeof value !== 'string') {
-    return false;
-  }
-  const match = value.match(/^\d{4}-\d{2}-\d{2}[T\s](\d{2}:\d{2}:\d{2})(?:\.\d{3})?(?:Z|[+-]\d\d:\d\d)?$/);
-  if (!match) {
-    return false;
-  }
-  return boundary === 'start' ? match[1] === '00:00:00' : match[1] === '23:59:59';
+export const DATE_PICKER_RANGE_VALUE_MODE = Symbol.for('tachybase.datePicker.rangeValueMode');
+
+export type DatePickerRangeValueMode = 'date' | 'datetime';
+
+export const getRangeValueMode = (value: any): DatePickerRangeValueMode | undefined => {
+  return Array.isArray(value) ? value[DATE_PICKER_RANGE_VALUE_MODE] : undefined;
 };
 
-const isDefaultRangeBoundaryValuePair = (value: any) => {
-  return (
-    Array.isArray(value) &&
-    value.length >= 2 &&
-    isDefaultRangeBoundaryValue(value[0], 'start') &&
-    isDefaultRangeBoundaryValue(value[value.length - 1], 'end')
-  );
+const markRangeValueMode = (value: any[], mode: DatePickerRangeValueMode) => {
+  Object.defineProperty(value, DATE_PICKER_RANGE_VALUE_MODE, {
+    configurable: true,
+    enumerable: false,
+    value: mode,
+  });
+  return value;
 };
 
 export const normalizeDatePickerParseOptions = (options: Moment2strOptions = {}) => {
@@ -73,7 +70,7 @@ export const normalizeDatePickerParseOptions = (options: Moment2strOptions = {})
     return options;
   }
 
-  if (options.showTime && !isDefaultRangeBoundaryValuePair(options.value)) {
+  if (options.showTime && getRangeValueMode(options.value) !== 'date') {
     return options;
   }
 
@@ -137,7 +134,10 @@ export const mapRangePicker = function () {
         if (onChange) {
           onChange(
             value
-              ? [moment2str(getRangeStart(value[0], props), props), moment2str(getRangeEnd(value[1], props), props)]
+              ? markRangeValueMode(
+                  [moment2str(getRangeStart(value[0], props), props), moment2str(getRangeEnd(value[1], props), props)],
+                  props.showTime ? 'datetime' : 'date',
+                )
               : [],
           );
         }

--- a/packages/client/src/schema-component/antd/date-picker/util.ts
+++ b/packages/client/src/schema-component/antd/date-picker/util.ts
@@ -53,7 +53,12 @@ export const DATE_PICKER_RANGE_VALUE_MODE = Symbol.for('tachybase.datePicker.ran
 
 export type DatePickerRangeValueMode = 'date' | 'datetime';
 
-export type DatePickerRangeValueSource = 'metadata' | 'schema' | 'retained-date-boundary' | 'unknown';
+export type DatePickerRangeValueSource =
+  | 'metadata'
+  | 'schema'
+  | 'retained-date-boundary'
+  | 'retained-local-date-boundary'
+  | 'unknown';
 
 export interface DatePickerRangeValueInfo {
   mode?: DatePickerRangeValueMode;
@@ -93,6 +98,24 @@ export const isDatePickerDefaultRangeBoundaryPair = (value: any) => {
   );
 };
 
+const isDatePickerLocalRangeBoundaryValue = (value: any, boundary: 'start' | 'end') => {
+  const m = dayjs(value);
+  if (!m.isValid()) {
+    return false;
+  }
+
+  return boundary === 'start' ? m.format('HH:mm:ss') === '00:00:00' : m.format('HH:mm:ss') === '23:59:59';
+};
+
+const isDatePickerRetainedLocalBoundaryPair = (value: any) => {
+  return (
+    Array.isArray(value) &&
+    value.length >= 2 &&
+    isDatePickerLocalRangeBoundaryValue(value[0], 'start') &&
+    isDatePickerLocalRangeBoundaryValue(value[value.length - 1], 'end')
+  );
+};
+
 export const resolveDatePickerRangeValueInfo = (
   value: any,
   options: { showTime?: boolean; component?: string; preferDateBoundaryFallback?: boolean } = {},
@@ -104,6 +127,10 @@ export const resolveDatePickerRangeValueInfo = (
 
   if (options.component === 'DatePicker.RangePicker' && !options.showTime) {
     return { mode: 'date', source: 'schema' };
+  }
+
+  if (options.preferDateBoundaryFallback && options.showTime && isDatePickerRetainedLocalBoundaryPair(value)) {
+    return { mode: 'date', source: 'retained-local-date-boundary' };
   }
 
   if (options.preferDateBoundaryFallback && isDatePickerDefaultRangeBoundaryPair(value)) {
@@ -124,8 +151,10 @@ export const normalizeDatePickerParseOptions = (options: Moment2strOptions = {})
     preferDateBoundaryFallback: options.component === 'DatePicker.RangePicker',
   });
 
-  if (options.showTime && rangeValueInfo.mode !== 'date') {
-    return options;
+  if (options.showTime) {
+    if (rangeValueInfo.mode !== 'date' || rangeValueInfo.source === 'retained-local-date-boundary') {
+      return options;
+    }
   }
 
   return {

--- a/packages/client/src/schema-component/antd/date-picker/util.ts
+++ b/packages/client/src/schema-component/antd/date-picker/util.ts
@@ -65,12 +65,36 @@ const markRangeValueMode = (value: any[], mode: DatePickerRangeValueMode) => {
   return value;
 };
 
+const isDefaultRangeBoundaryValue = (value: any, boundary: 'start' | 'end') => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const match = value.match(/^\d{4}-\d{2}-\d{2}[T\s](\d{2}:\d{2}:\d{2})(?:\.\d{3})?(?:Z|[+-]\d\d:\d\d)?$/);
+  if (!match) {
+    return false;
+  }
+  return boundary === 'start' ? match[1] === '00:00:00' : match[1] === '23:59:59';
+};
+
+const isDefaultRangeBoundaryValuePair = (value: any) => {
+  return (
+    Array.isArray(value) &&
+    value.length >= 2 &&
+    isDefaultRangeBoundaryValue(value[0], 'start') &&
+    isDefaultRangeBoundaryValue(value[value.length - 1], 'end')
+  );
+};
+
 export const normalizeDatePickerParseOptions = (options: Moment2strOptions = {}) => {
   if (options.utc === false || typeof options.gmt === 'boolean' || options.picker) {
     return options;
   }
 
-  if (options.showTime && getRangeValueMode(options.value) !== 'date') {
+  if (
+    options.showTime &&
+    getRangeValueMode(options.value) !== 'date' &&
+    !isDefaultRangeBoundaryValuePair(options.value)
+  ) {
     return options;
   }
 

--- a/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
+++ b/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, userEvent, waitFor, within } from '@tachybase/test/clie
 
 import dayjs from 'dayjs';
 
+import { mapRangePicker } from '../../date-picker/util';
 import App2 from '../demos/demo2';
 import App3 from '../demos/demo3';
 import App4 from '../demos/demo4';
@@ -389,11 +390,19 @@ describe('Filter', () => {
     });
   });
 
-  it('preserves explicit midnight points for date-between custom filter values', () => {
-    const start = '2026-05-01T00:00:00.000Z';
-    const end = '2026-05-19T00:00:00.000Z';
+  it('uses retained date-only range metadata for custom filter values after enabling time', () => {
+    let rangeValue: any[];
+    const dateOnlyMapped = mapRangePicker()({
+      showTime: false,
+      utc: true,
+      onChange: (nextValue: any[]) => {
+        rangeValue = nextValue;
+      },
+    });
+    dateOnlyMapped.onChange([dayjs('2026-05-01 00:00:00'), dayjs('2026-05-19 00:00:00')]);
+
     const condition = getCustomCondition(
-      { date: [start, end] },
+      { date: rangeValue },
       {
         properties: {
           '__custom.date': {
@@ -420,7 +429,56 @@ describe('Filter', () => {
       $and: [
         {
           date_pay: {
-            $dateBetween: [dayjs(start).toISOString(), dayjs(end).toISOString()],
+            $dateBetween: [
+              dayjs('2026-05-01 00:00:00').startOf('day').toISOString(),
+              dayjs('2026-05-19 23:59:59.999').endOf('day').toISOString(),
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it('preserves explicit boundary-looking datetime metadata for custom filter values', () => {
+    let rangeValue: any[];
+    const datetimeMapped = mapRangePicker()({
+      showTime: true,
+      utc: true,
+      onChange: (nextValue: any[]) => {
+        rangeValue = nextValue;
+      },
+    });
+    datetimeMapped.onChange([dayjs('2026-05-01 00:00:00'), dayjs('2026-05-19 23:59:59')]);
+
+    const condition = getCustomCondition(
+      { date: rangeValue },
+      {
+        properties: {
+          '__custom.date': {
+            name: '__custom.date',
+            'x-component': 'DatePicker.RangePicker',
+            'x-component-props': {
+              showTime: true,
+            },
+          },
+        },
+        'x-filter-rules': {
+          $and: [
+            {
+              date_pay: {
+                $dateBetween: '{{$nFilter.date}}',
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(condition).toEqual({
+      $and: [
+        {
+          date_pay: {
+            $dateBetween: [dayjs(rangeValue[0]).toISOString(), dayjs(rangeValue[1]).toISOString()],
           },
         },
       ],

--- a/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
+++ b/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
@@ -267,12 +267,12 @@ describe('Filter', () => {
           $or: [
             {
               date_pay: {
-                $dateBetween: [start, end],
+                $dateBetween: [dayjs(start).startOf('day').toISOString(), dayjs(end).endOf('day').toISOString()],
               },
             },
             {
               date_receive: {
-                $dateBetween: [start, end],
+                $dateBetween: [dayjs(start).startOf('day').toISOString(), dayjs(end).endOf('day').toISOString()],
               },
             },
           ],
@@ -423,14 +423,17 @@ describe('Filter', () => {
       $and: [
         {
           date_pay: {
-            $dateBetween: rangeValue,
+            $dateBetween: [
+              dayjs('2026-05-01 00:00:00').startOf('day').toISOString(),
+              dayjs('2026-05-19 23:59:59.999').endOf('day').toISOString(),
+            ],
           },
         },
       ],
     });
   });
 
-  it('uses retained date-only range fallback for custom filter values when metadata is lost', () => {
+  it('normalizes retained date-only range fallback for custom filter values when metadata is lost', () => {
     let rangeValue: any[];
     const dateOnlyMapped = mapRangePicker()({
       showTime: false,
@@ -470,7 +473,10 @@ describe('Filter', () => {
       $and: [
         {
           date_pay: {
-            $dateBetween: copiedRangeValue,
+            $dateBetween: [
+              dayjs('2026-05-01 00:00:00').startOf('day').toISOString(),
+              dayjs('2026-05-19 23:59:59.999').endOf('day').toISOString(),
+            ],
           },
         },
       ],

--- a/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
+++ b/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
@@ -267,18 +267,12 @@ describe('Filter', () => {
           $or: [
             {
               date_pay: {
-                $dateBetween: [
-                  dayjs(start.replace(/Z$/, '')).startOf('day').toISOString(),
-                  dayjs(end.replace(/Z$/, '')).endOf('day').toISOString(),
-                ],
+                $dateBetween: [start, end],
               },
             },
             {
               date_receive: {
-                $dateBetween: [
-                  dayjs(start.replace(/Z$/, '')).startOf('day').toISOString(),
-                  dayjs(end.replace(/Z$/, '')).endOf('day').toISOString(),
-                ],
+                $dateBetween: [start, end],
               },
             },
           ],
@@ -429,10 +423,54 @@ describe('Filter', () => {
       $and: [
         {
           date_pay: {
-            $dateBetween: [
-              dayjs('2026-05-01 00:00:00').startOf('day').toISOString(),
-              dayjs('2026-05-19 23:59:59.999').endOf('day').toISOString(),
-            ],
+            $dateBetween: rangeValue,
+          },
+        },
+      ],
+    });
+  });
+
+  it('uses retained date-only range fallback for custom filter values when metadata is lost', () => {
+    let rangeValue: any[];
+    const dateOnlyMapped = mapRangePicker()({
+      showTime: false,
+      utc: true,
+      onChange: (nextValue: any[]) => {
+        rangeValue = nextValue;
+      },
+    });
+    dateOnlyMapped.onChange([dayjs('2026-05-01 00:00:00'), dayjs('2026-05-19 00:00:00')]);
+
+    const copiedRangeValue = [rangeValue[0], rangeValue[1]];
+    const condition = getCustomCondition(
+      { date: copiedRangeValue },
+      {
+        properties: {
+          '__custom.date': {
+            name: '__custom.date',
+            'x-component': 'DatePicker.RangePicker',
+            'x-component-props': {
+              showTime: true,
+            },
+          },
+        },
+        'x-filter-rules': {
+          $and: [
+            {
+              date_pay: {
+                $dateBetween: '{{$nFilter.date}}',
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(condition).toEqual({
+      $and: [
+        {
+          date_pay: {
+            $dateBetween: copiedRangeValue,
           },
         },
       ],

--- a/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -13,6 +13,7 @@ import {
   shouldUseDefaultDateBoundary,
 } from '../../../filter-provider/utils';
 import { useDataLoadingMode } from '../../../modules/blocks/data-blocks/details-multi/setDataLoadingModeSettingsItem';
+import { resolveDatePickerRangeValueInfo } from '../date-picker/util';
 import { hasDuplicateKeys } from './utils';
 
 export const useGetFilterOptions = () => {
@@ -206,11 +207,28 @@ const findCustomFieldSchema = (schema, key) => {
   return null;
 };
 
+const getDatePickerComponent = (fieldSchema?: any) => {
+  return fieldSchema?.['x-component'] || fieldSchema?.['x-component-props']?.component;
+};
+
+const getDatePickerShowTime = (fieldSchema?: any) => {
+  return fieldSchema?.['x-component-props']?.showTime;
+};
+
 const expandArrayValueFilter = (filterSchemaItem, filterKey, value, customFlat, options: any = {}) => {
   const pathParts = filterKey.split('.');
   const operator = pathParts.pop();
   if (operator === '$dateBetween' && Array.isArray(value)) {
-    filterSchemaItem[filterKey] = normalizeDateBetweenValue(value, options);
+    const valueInfo = resolveDatePickerRangeValueInfo(value, {
+      component: options.component,
+      showTime: options.showTime,
+      preferDateBoundaryFallback: options.useDefaultDateBoundary,
+    });
+    filterSchemaItem[filterKey] = normalizeDateBetweenValue(value, {
+      useDefaultDateBoundary: options.useDefaultDateBoundary,
+      valueMode: valueInfo.mode,
+      preferDateBoundaryFallback: valueInfo.source === 'retained-date-boundary',
+    });
     return;
   }
 
@@ -257,6 +275,8 @@ export const getCustomCondition: any = (filter, fieldSchema, customFlat = flat) 
           customFlat,
           {
             useDefaultDateBoundary: shouldUseDefaultDateBoundary(customFieldSchema),
+            component: getDatePickerComponent(customFieldSchema),
+            showTime: getDatePickerShowTime(customFieldSchema),
           },
         );
       }

--- a/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -157,7 +157,11 @@ const isEmpty = (obj) => {
 
 const CUSTOM_FILTER_VARIABLE_REGEXP = /^\{\{\$nFilter\.([^}]+)\}\}$/;
 
-const getCustomFilterValue = (items, key) => {
+const getCustomFilterValue = (items, key, rawItems: any = {}) => {
+  if (rawItems && key in rawItems) {
+    return rawItems[key];
+  }
+
   if (key in items) {
     return items[key];
   }
@@ -246,9 +250,15 @@ export const getCustomCondition: any = (filter, fieldSchema, customFlat = flat) 
           continue;
         }
         const customFieldSchema = findCustomFieldSchema(fieldSchema, match[1]);
-        expandArrayValueFilter(filterSchemaItem, filterKey, getCustomFilterValue(items, match[1]), customFlat, {
-          useDefaultDateBoundary: shouldUseDefaultDateBoundary(customFieldSchema),
-        });
+        expandArrayValueFilter(
+          filterSchemaItem,
+          filterKey,
+          getCustomFilterValue(items, match[1], filter || {}),
+          customFlat,
+          {
+            useDefaultDateBoundary: shouldUseDefaultDateBoundary(customFieldSchema),
+          },
+        );
       }
       for (const item in filterSchemaItem) {
         if (!filterSchemaItem[item] || filterSchemaItem[item].includes('$nFilter')) {

--- a/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -227,6 +227,7 @@ const expandArrayValueFilter = (filterSchemaItem, filterKey, value, customFlat, 
     filterSchemaItem[filterKey] = normalizeDateBetweenValue(value, {
       useDefaultDateBoundary: options.useDefaultDateBoundary,
       valueMode: valueInfo.mode,
+      valueSource: valueInfo.source,
       preferDateBoundaryFallback: valueInfo.source === 'retained-date-boundary',
     });
     return;


### PR DESCRIPTION
## Summary

- Unify DatePicker.RangePicker date/datetime semantics across ordinary and custom filters.
- Preserve explicit datetime range values while normalizing date-only ranges to full-day boundaries.
- Keep retained date-only ranges consistent after enabling `showTime`, even when range metadata is lost.
- Expand custom filter variable substitution for array values and shared `$dateBetween` normalization.

## Details

This centralizes RangePicker value classification in the DatePicker utility layer and makes both ordinary filter submission and custom filter variable substitution consume the same `$dateBetween` normalizer.

The implementation distinguishes:

- live metadata-backed date ranges
- live metadata-backed datetime ranges
- retained raw date boundary values
- retained already-converted local boundary values
- unknown/exact datetime values

This avoids the previous divergence where ordinary and custom filters could display or submit different time boundaries for the same retained RangePicker value.

## Test plan

- Manual browser verification on ordinary and custom filters:
  - date-only RangePicker submission
  - datetime RangePicker submission
  - date-only values retained after switching to `showTime`
  - custom filter variables targeting multiple date fields
- `git diff --check`
- `pnpm oxlint packages/client/src/schema-component/antd/date-picker/util.ts packages/client/src/filter-provider/utils.ts packages/client/src/schema-component/antd/filter/useFilterActionProps.ts`

Focused Vitest is currently blocked by the existing repo config issue:

Missing "./vitest.mjs" specifier in "@tachybase/test" package
