### PR TITLE
fix(client): unify regular and custom date range filter boundary semantics

### DIFF
--- a/packages/client/src/filter-provider/__tests__/transformToFilter.ts
+++ b/packages/client/src/filter-provider/__tests__/transformToFilter.ts
@@ -238,6 +238,44 @@ describe('transformToFilter', () => {
     });
   });
 
+  it('should infer date range semantics from CollectionField component props', () => {
+    const values = {
+      date_receive: ['2026-04-30T16:00:00.000Z', '2026-05-03T15:59:59.999Z'],
+    };
+
+    const fieldSchema = {
+      'x-filter-operators': {
+        date_receive: '$dateBetween',
+      },
+      properties: {
+        date_receive: {
+          name: 'date_receive',
+          'x-component': 'CollectionField',
+          'x-collection-field': 'receipt.date_receive',
+          'x-component-props': {
+            component: 'DatePicker.RangePicker',
+            showTime: false,
+          },
+        },
+      },
+    };
+
+    const getField = () => ({
+      targetKey: undefined,
+      interface: 'datetime',
+    });
+
+    expect(transformToFilter(values, fieldSchema as any, getField, 'receipt')).toEqual({
+      $and: [
+        {
+          date_receive: {
+            $dateBetween: values.date_receive,
+          },
+        },
+      ],
+    });
+  });
+
   it('should preserve explicit boundary-looking times from datetime range fields', () => {
     let rangeValue: any[];
     const datetimeMapped = mapRangePicker()({

--- a/packages/client/src/filter-provider/utils.ts
+++ b/packages/client/src/filter-provider/utils.ts
@@ -186,6 +186,9 @@ type NormalizeDateBetweenOptions = {
 };
 
 const getDatePickerComponent = (fieldSchema?: any) => {
+  if (fieldSchema?.['x-component'] === 'CollectionField') {
+    return fieldSchema?.['x-component-props']?.component;
+  }
   return fieldSchema?.['x-component'] || fieldSchema?.['x-component-props']?.component;
 };
 
@@ -223,7 +226,7 @@ const normalizeDateBetweenBoundary = (
   }
 
   if (options.valueMode === 'date') {
-    if (options.valueSource === 'retained-local-date-boundary') {
+    if (options.valueSource === 'metadata' || options.valueSource === 'retained-local-date-boundary') {
       return m.toISOString();
     }
     const localBoundary = dayjs(normalizeLocalDateBoundaryInput(value));
@@ -357,13 +360,15 @@ export const transformToFilter = (
           }
         } else if (operator === '$dateBetween') {
           if (Array.isArray(value)) {
+            const datePickerComponent = getDatePickerComponent(currentFieldSchema);
+            const useDefaultDateBoundary = shouldUseDefaultDateBoundary(currentFieldSchema);
             const valueInfo = resolveDatePickerRangeValueInfo(value, {
-              component: getDatePickerComponent(currentFieldSchema),
+              component: datePickerComponent,
               showTime: getDatePickerShowTime(currentFieldSchema),
-              preferDateBoundaryFallback: shouldUseDefaultDateBoundary(currentFieldSchema),
+              preferDateBoundaryFallback: useDefaultDateBoundary,
             });
             value = normalizeDateBetweenValue(value, {
-              useDefaultDateBoundary: shouldUseDefaultDateBoundary(currentFieldSchema),
+              useDefaultDateBoundary,
               valueMode: valueInfo.mode,
               valueSource: valueInfo.source,
               preferDateBoundaryFallback: valueInfo.source === 'retained-date-boundary',

--- a/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
+++ b/packages/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
@@ -223,6 +223,16 @@ describe('mapRangePicker', () => {
       mode: 'date',
       source: 'retained-local-date-boundary',
     });
+
+    expect(
+      resolveDatePickerRangeValueInfo(['2026-05-01T16:00:00.000Z', '2026-05-03T15:59:59.999Z'], {
+        component: 'DatePicker.RangePicker',
+        preferDateBoundaryFallback: true,
+      }),
+    ).toEqual({
+      mode: 'date',
+      source: 'retained-local-date-boundary',
+    });
   });
 
   test('should parse date-only range values with GMT semantics when gmt is not specified', () => {

--- a/packages/client/src/schema-component/antd/date-picker/util.ts
+++ b/packages/client/src/schema-component/antd/date-picker/util.ts
@@ -122,15 +122,18 @@ export const resolveDatePickerRangeValueInfo = (
 ): DatePickerRangeValueInfo => {
   const metadataMode = getRangeValueMode(value);
   if (metadataMode) {
+    if (metadataMode === 'date' && isDatePickerDefaultRangeBoundaryPair(value)) {
+      return { mode: 'date', source: 'retained-date-boundary' };
+    }
     return { mode: metadataMode, source: 'metadata' };
+  }
+
+  if (options.preferDateBoundaryFallback && isDatePickerRetainedLocalBoundaryPair(value)) {
+    return { mode: 'date', source: 'retained-local-date-boundary' };
   }
 
   if (options.component === 'DatePicker.RangePicker' && !options.showTime) {
     return { mode: 'date', source: 'schema' };
-  }
-
-  if (options.preferDateBoundaryFallback && options.showTime && isDatePickerRetainedLocalBoundaryPair(value)) {
-    return { mode: 'date', source: 'retained-local-date-boundary' };
   }
 
   if (options.preferDateBoundaryFallback && isDatePickerDefaultRangeBoundaryPair(value)) {
@@ -141,7 +144,7 @@ export const resolveDatePickerRangeValueInfo = (
 };
 
 export const normalizeDatePickerParseOptions = (options: Moment2strOptions = {}) => {
-  if (options.utc === false || typeof options.gmt === 'boolean' || options.picker) {
+  if (options.utc === false || options.gmt === true || options.picker) {
     return options;
   }
 
@@ -157,10 +160,8 @@ export const normalizeDatePickerParseOptions = (options: Moment2strOptions = {})
     }
   }
 
-  return {
-    ...options,
-    gmt: true,
-  };
+  const { gmt, ...rest } = options;
+  return rest;
 };
 
 export const moment2str = (value?: Dayjs | null, options: Moment2strOptions = {}) => {

--- a/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
+++ b/packages/client/src/schema-component/antd/filter/__tests__/filter.test.tsx
@@ -532,6 +532,44 @@ describe('Filter', () => {
     });
   });
 
+  it('normalizes CollectionField date range values from component props', () => {
+    const values = ['2026-04-30T16:00:00.000Z', '2026-05-03T15:59:59.999Z'];
+    const condition = getCustomCondition(
+      { date: values },
+      {
+        properties: {
+          '__custom.date': {
+            name: '__custom.date',
+            'x-component': 'CollectionField',
+            'x-component-props': {
+              component: 'DatePicker.RangePicker',
+              showTime: false,
+            },
+          },
+        },
+        'x-filter-rules': {
+          $and: [
+            {
+              date_receive: {
+                $dateBetween: '{{$nFilter.date}}',
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(condition).toEqual({
+      $and: [
+        {
+          date_receive: {
+            $dateBetween: values,
+          },
+        },
+      ],
+    });
+  });
+
   it('preserves explicit boundary-looking datetime metadata for custom filter values', () => {
     let rangeValue: any[];
     const datetimeMapped = mapRangePicker()({

--- a/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -208,6 +208,9 @@ const findCustomFieldSchema = (schema, key) => {
 };
 
 const getDatePickerComponent = (fieldSchema?: any) => {
+  if (fieldSchema?.['x-component'] === 'CollectionField') {
+    return fieldSchema?.['x-component-props']?.component;
+  }
   return fieldSchema?.['x-component'] || fieldSchema?.['x-component-props']?.component;
 };
 

--- a/packages/client/src/schema-initializer/items/CustomFilterFormItemInitializer.tsx
+++ b/packages/client/src/schema-initializer/items/CustomFilterFormItemInitializer.tsx
@@ -9,8 +9,8 @@ import {
   useField,
   useFieldSchema,
 } from '@tachybase/schema';
-
 import { ArrayItems, FormLayout } from '@tego/client';
+
 import { ConfigProvider, Space } from 'antd';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -312,9 +312,10 @@ export const FilterCustomItemInitializer: React.FC<{
       },
       collectionName: collection,
     };
-    if (component === 'DatePicker') {
+    if (component === 'DatePicker' || component === 'DatePicker.RangePicker') {
       schema['x-settings'] = 'fieldSettings:FilterFormItem';
       schema['x-designer-props'] = { interface: 'datetime' };
+      schema['x-component-props'] = { ...schema['x-component-props'], gmt: false };
     }
     insert(gridRowColWrap(schema));
 


### PR DESCRIPTION
Regular filter fields had gmt:false from database field config, producing proper UTC day boundaries via toLocalByPicker. Custom DatePicker filters lacked this flag, outputting naive GMT (local-time + Z suffix) instead. This caused inconsistent $dateBetween values between the two filter types.

- schema generation: set gmt:false for new custom DatePicker/RangePicker filters, matching regular field behavior at the source
- component detection: getDatePickerComponent now reads CollectionField's x-component-props.component to identify the underlying RangePicker
- value normalization: metadata-date values are preserved as-is; naive GMT boundaries within metadata are detected and routed to proper timezone normalization via retained-date-boundary
- local boundary detection: retained-local-date-boundary check runs before the schema branch, preventing double-normalization of already-converted UTC values
- parse options: gmt:false no longer short-circuits normalization, letting str2moment use its default Z-aware parsing for correct display