### PR TITLE
fix(client): preserve gmt:true parse for naive GMT date boundary values

### DIFF
--- a/packages/client/src/schema-component/antd/date-picker/util.ts
+++ b/packages/client/src/schema-component/antd/date-picker/util.ts
@@ -161,6 +161,14 @@ export const normalizeDatePickerParseOptions = (options: Moment2strOptions = {})
   }
 
   const { gmt, ...rest } = options;
+
+  // retained-date-boundary values are naive GMT (local-time + Z suffix),
+  // str2moment needs gmt:true to interpret them in GMT mode for correct display.
+  if (rangeValueInfo.source === 'retained-date-boundary') {
+    return { ...rest, gmt: true };
+  }
+
+  // strip gmt so str2moment uses default local-time parsing for proper UTC values
   return rest;
 };
 


### PR DESCRIPTION
Custom DatePicker filters without gmt:false produce naive GMT values (local-time + Z suffix). Stripping gmt from the parse options caused str2moment to interpret these as UTC, shifting the displayed time by the local offset. retained-date-boundary values now keep gmt:true so they are parsed in GMT mode for correct display.