### PR TITLE
fix(client): resolve circular dependency causing white screen

### DIFF
--- a/packages/client/src/application/schema-settings/components/SchemaSettingsChildren.tsx
+++ b/packages/client/src/application/schema-settings/components/SchemaSettingsChildren.tsx
@@ -23,7 +23,7 @@ export interface SchemaSettingsChildrenProps {
   children: SchemaSettingsItemType[];
 }
 
-const typeComponentMap = {
+const getTypeComponentMap = () => ({
   item: SchemaSettingsItem,
   itemGroup: SchemaSettingsItemGroup,
   subMenu: SchemaSettingsSubMenu,
@@ -35,7 +35,7 @@ const typeComponentMap = {
   popup: SchemaSettingsPopupItem,
   actionModal: SchemaSettingsActionModalItem,
   modal: SchemaSettingsModalItem,
-};
+});
 
 export const SchemaSettingsChildren: FC<SchemaSettingsChildrenProps> = (props) => {
   const { children } = props;
@@ -98,7 +98,7 @@ export const SchemaSettingsChild: FC<SchemaSettingsItemType> = memo((props) => {
   }, [useChildrenRes, children]);
   const visibleResult = useVisible();
   const ComponentValue = useMemo(() => {
-    return !Component && type && typeComponentMap[type] ? typeComponentMap[type] : Component;
+    return !Component && type ? getTypeComponentMap()[type] : Component;
   }, [type, Component]);
 
   if (!visibleResult) return null;

--- a/packages/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { Field, ISchema, observer, useField, useFieldSchema } from '@tachybase/schema';
-
 import { error } from '@tego/client';
+
 import { Select } from 'antd';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import { GeneralSchemaDesigner, SchemaSettingsItem } from '../..';
 import { useFormBlockContext } from '../../../block-provider';
 import { useCollectionManager_deprecated } from '../../../collection-manager';
 import { mergeFilter } from '../../../filter-provider/utils';
 import { removeNullCondition, useCompile, useDesignable } from '../../../schema-component';
 import { ITemplate } from '../../../schema-component/antd/form-v2/Templates';
+import { GeneralSchemaDesigner } from '../../GeneralSchemaDesigner';
+import { SchemaSettingsItem } from '../../SchemaSettings';
 import { SchemaSettingsDataScope } from '../../SchemaSettingsDataScope';
 
 export const Designer = observer(


### PR DESCRIPTION
- SchemaSettingsChildren.tsx: Convert module-level typeComponentMap to lazy getTypeComponentMap() function to avoid accessing SchemaSettingsItem before initialization during module loading
- Designer.tsx: Fix import path from '../..' to specific files to break circular dependency chain

Fixes: Cannot access 'SchemaSettingsItem' before initialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Refactor**
  * 优化内部代码结构以提高代码可维护性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->