### PR TITLE
fix(client): resolve fieldNames for deeply nested association fields in filter forms

### DIFF
--- a/packages/client/src/schema-component/antd/association-field/AssociationSelect.tsx
+++ b/packages/client/src/schema-component/antd/association-field/AssociationSelect.tsx
@@ -20,7 +20,7 @@ import { RecordProvider, useAPIClient, useApp, useCollectionRecordData } from '.
 import { isVariable } from '../../../variables/utils/isVariable';
 import { getInnermostKeyAndValue } from '../../common/utils/uitls';
 import { RemoteSelect, RemoteSelectProps } from '../remote-select';
-import useServiceOptions, { useAssociationFieldContext } from './hooks';
+import useServiceOptions, { useAssociationFieldContext, useFieldNames } from './hooks';
 
 export type AssociationSelectProps<P = any> = RemoteSelectProps<P> & {
   action?: string;
@@ -66,6 +66,7 @@ const InternalAssociationSelect = observer(
     const isAllowAddNew = fieldSchema['x-add-new'];
     const { t } = useTranslation();
     const { multiple } = props;
+    const fieldNames = useFieldNames(props);
     const form = useForm();
     const api = useAPIClient();
     const resource = api.resource(collectionField.target);
@@ -136,6 +137,7 @@ const InternalAssociationSelect = observer(
           <RemoteSelect
             style={{ width: '100%' }}
             {...props}
+            fieldNames={fieldNames}
             size={'middle'}
             objectValue={objectValue}
             value={value || innerValue}

--- a/packages/client/src/schema-component/antd/association-field/AssociationSelect.tsx
+++ b/packages/client/src/schema-component/antd/association-field/AssociationSelect.tsx
@@ -103,7 +103,7 @@ const InternalAssociationSelect = observer(
         data: { data },
       } = await resource.create({
         values: {
-          [field?.componentProps?.fieldNames?.label || 'id']: value,
+          [fieldNames.label || 'id']: value,
         },
       });
       if (data) {

--- a/packages/client/src/schema-component/antd/association-field/hooks.ts
+++ b/packages/client/src/schema-component/antd/association-field/hooks.ts
@@ -172,11 +172,26 @@ export default function useServiceOptions(props) {
 
 export const useFieldNames = (props) => {
   const fieldSchema = useFieldSchema();
+  const { options: collectionField } = useAssociationFieldContext();
+  const { getCollection } = useCollectionManager_deprecated();
   const fieldNames =
     fieldSchema['x-component-props']?.['field']?.['uiSchema']?.['x-component-props']?.['fieldNames'] ||
     fieldSchema?.['x-component-props']?.['fieldNames'] ||
     props.fieldNames;
-  return { label: 'label', value: 'value', ...fieldNames };
+  if (fieldNames) {
+    return { label: 'label', value: 'value', ...fieldNames };
+  }
+  // For association fields without explicit fieldNames (e.g. deeply nested
+  // paths in filter forms), derive the label/value from the target collection's
+  // title field so that the Select dropdown can display options correctly.
+  if (collectionField?.target) {
+    const targetCollection = getCollection(collectionField.target);
+    if (targetCollection) {
+      const pk = targetCollection.filterTargetKey || targetCollection.getPrimaryKey?.() || 'id';
+      return { label: targetCollection.titleField || pk, value: pk };
+    }
+  }
+  return { label: 'label', value: 'value' };
 };
 
 const SubFormContext = createContext<{


### PR DESCRIPTION
…in filter forms

When a CollectionField with a deeply nested association path (e.g. receipt.accountItemList.accounts.glAccount) is used in a filter form, the schema's x-component-props is empty {}, so useFieldNames() falls back to the default {label:'label', value:'value'}.

Since the actual data uses 'name' and 'id' fields, the Select dropdown filters out all options and shows '暂无数据' (No data).

Fix: when no explicit fieldNames are configured, derive the label/value from the target collection's titleField and primaryKey via the AssociationFieldContext.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了关联字段的字段名称与取值映射：在未显式配置字段名时，现会基于目标集合信息自动推导标签和值字段（并在缺失时提供合理默认）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->